### PR TITLE
adding custom WP CLI command and optional admin screen

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
     "scripts": {
         "test-init": "bin/install-wp-tests.sh wordpress_tests root \"\"",
         "test": "phpunit"
+    },
+    "autoload": {
+        "psr-4": {
+            "Fastly_IO\\": "src/classes/"
+        }
     }
 }

--- a/src/classes/class-fastly-media-regen-admin.php
+++ b/src/classes/class-fastly-media-regen-admin.php
@@ -1,0 +1,98 @@
+<?php
+namespace FastlyIO\Admin;
+
+use WP_CLI;
+use WP_CLI_Command;
+
+class FastlyMediaRegenAdmin
+{
+    public function __construct()
+    {
+        add_action('admin_menu', [$this, 'add_admin_page']);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_scripts']);
+        add_action('wp_ajax_fastly_media_regen', [$this, 'handle_ajax_request']);
+    }
+
+    /**
+     * Adds the admin page under Tools.
+     */
+    public function add_admin_page()
+    {
+        add_submenu_page(
+            'tools.php',
+            'Fastly Media Regen',
+            'Fastly Media Regen',
+            'manage_options',
+            'fastly-media-regen',
+            [$this, 'render_admin_page']
+        );
+    }
+
+    /**
+     * Enqueues JavaScript for AJAX handling.
+     */
+    public function enqueue_scripts($hook)
+    {
+        if ($hook !== 'tools_page_fastly-media-regen') {
+            return;
+        }
+
+        wp_enqueue_script(
+            'fastly-media-regen-js',
+            plugin_dir_url(__FILE__) . '../js/fastly-media-regen.js',
+            ['jquery'],
+            null,
+            true
+        );
+
+        wp_localize_script('fastly-media-regen-js', 'fastlyMediaRegen', [
+            'ajax_url' => admin_url('admin-ajax.php'),
+            'nonce'    => wp_create_nonce('fastly_media_regen_nonce')
+        ]);
+    }
+
+    /**
+     * Renders the admin page.
+     */
+    public function render_admin_page()
+    {
+        ?>
+        <div class="wrap">
+            <h1>Fastly Media Regeneration</h1>
+            <p>Click the button below to regenerate all images.</p>
+            <button id="fastly-media-regen-btn" class="button button-primary">Regenerate Media</button>
+            <p>&nbsp;</p>
+            <p><strong>Output:</strong></p>
+            <textarea id="fastly-media-regen-output" rows="10" cols="100" readonly></textarea>
+        </div>
+        <?php
+    }
+
+    /**
+     * Handles AJAX request to run the regeneration.
+     */
+   /**
+ * Handles AJAX request to run the regeneration.
+ */
+public function handle_ajax_request()
+{
+    check_ajax_referer('fastly_media_regen_nonce', 'nonce');
+
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error('Unauthorized', 403);
+    }
+
+    // Run WP-CLI command via shell_exec (Make sure WP-CLI is available in system path)
+    $command = 'wp fastlyio media regenerate --allow-root 2>&1';
+    $output = shell_exec($command);
+
+    if (!$output) {
+        wp_send_json_error(['message' => 'WP-CLI command failed to execute.']);
+    } else {
+        wp_send_json_success(['output' => $output]);
+    }
+}
+
+}
+
+new FastlyMediaRegenAdmin();

--- a/src/classes/class-fastly-media-regen.php
+++ b/src/classes/class-fastly-media-regen.php
@@ -1,0 +1,122 @@
+<?php
+namespace Fastly_IO\CLI;
+
+use WP_CLI;
+use WP_CLI_Command;
+
+if (!class_exists('WP_CLI')) {
+    return;
+}
+
+/**
+ * Class FastlyMediaRegen
+ *
+ * Hooks into `wp media regenerate` to output metadata before regeneration.
+ *
+ * @package Fastly_IO\CLI
+ */
+class FastlyMediaRegen extends WP_CLI_Command
+{
+    /**
+     * Regenerates media thumbnails while outputting metadata beforehand.
+     *
+     * ## OPTIONS
+     *
+     * [--verbose]
+     * : Show detailed output.
+     *
+     * ## EXAMPLES
+     *
+     *     wp media regenerate
+     *     wp media regenerate --verbose
+     *
+     * @param array $args        Positional arguments (attachment IDs or empty).
+     * @param array $assoc_args  Associative arguments.
+     */
+    public function regenerate($args, $assoc_args)
+    {
+        $verbose = isset($assoc_args['verbose']);
+
+        // Get media IDs from args or default to all attachments
+        $attachment_ids = !empty($args) ? array_map('intval', $args) : $this->get_all_attachment_ids();
+
+        if (empty($attachment_ids)) {
+            WP_CLI::warning('No media attachments found.');
+            return;
+        }
+
+        $filtered_ids = [];
+        foreach ($attachment_ids as $attachment_id) {
+            if ($this->has_image_meta($attachment_id)) {
+                // Output metadata before regenerating
+                $this->output_metadata($attachment_id, $verbose);
+                $filtered_ids[] = $attachment_id;
+            }
+        }
+
+        if (!empty($filtered_ids)) {
+            // Call the original `wp media regenerate` command only on filtered images
+            WP_CLI::runcommand('media regenerate ' . implode(' ', $filtered_ids) . ($verbose ? ' --verbose' : ''));
+        } else {
+            WP_CLI::warning('No valid images with image_meta found for regeneration.');
+        }
+    }
+
+
+    /**
+     * Outputs media metadata.
+     *
+     * @param int  $attachment_id The attachment ID.
+     * @param bool $verbose       Whether to show detailed output.
+     */
+    private function output_metadata($attachment_id, $verbose)
+    {
+        $metadata = wp_get_attachment_metadata($attachment_id);
+        $mime_type = get_post_mime_type($attachment_id);
+
+        if (!$metadata) {
+            WP_CLI::warning("No metadata found for attachment ID: $attachment_id");
+            return;
+        }
+
+        WP_CLI::log("Metadata for Attachment ID: $attachment_id");
+        WP_CLI::log("MIME Type: " . ($mime_type ?: 'Unknown'));
+
+        if (isset($metadata['image_meta'])) {
+            WP_CLI::log("Image metadata found. Proceeding with regeneration.");
+        } else {
+            WP_CLI::log("No image meta data is present. The mime type is " . $mime_type . " This is likely not an image, skipping regeneration.");
+        }
+
+    }
+
+    /**
+     * Checks if an attachment has image_meta.
+     *
+     * @param int $attachment_id The attachment ID.
+     * @return bool True if image_meta is present, false otherwise.
+     */
+    private function has_image_meta($attachment_id)
+    {
+        $metadata = wp_get_attachment_metadata($attachment_id);
+        return isset($metadata['image_meta']);
+    }
+
+    /**
+     * Gets all attachment IDs.
+     *
+     * @return array Attachment IDs.
+     */
+    private function get_all_attachment_ids()
+    {
+        return get_posts([
+            'post_type'      => 'attachment',
+            'post_status'    => 'inherit',
+            'posts_per_page' => -1,
+            'fields'         => 'ids',
+        ]);
+    }
+}
+
+// Register the command, overriding `wp media regenerate`
+WP_CLI::add_command('fastlyio media', __NAMESPACE__ . '\\FastlyMediaRegen');

--- a/src/js/fastly-media-regen.js
+++ b/src/js/fastly-media-regen.js
@@ -1,0 +1,31 @@
+jQuery(document).ready(function ($) {
+    $('#fastly-media-regen-btn').on('click', function () {
+        let $button = $(this);
+        let $output = $('#fastly-media-regen-output');
+        
+        $button.prop('disabled', true).text('Regenerating...');
+        $output.val('Running media regeneration...\n');
+        
+        $.ajax({
+            url: fastlyMediaRegen.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'fastly_media_regen',
+                nonce: fastlyMediaRegen.nonce
+            },
+            success: function (response) {
+                if (response.success) {
+                    $output.val(response.data.output);
+                } else {
+                    $output.val('Error: ' + response.data);
+                }
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                $output.val('An error occurred: ' + textStatus + ' - ' + errorThrown + '\nResponse: ' + jqXHR.responseText);
+            },
+            complete: function () {
+                $button.prop('disabled', false).text('Regenerate Media');
+            }
+        });
+    });
+});


### PR DESCRIPTION
This PR adds a custom hook into the `wp media regenerate` command. This will only regenerate attachments that have image metadata, thus skipping PDFs.

Still is a WIP, and am working on batching and multisite support. Also, deleting variants without resizing for non-image attachments.